### PR TITLE
Fix: Correct Loon RULE-SET syntax

### DIFF
--- a/configs/loon/complete.conf
+++ b/configs/loon/complete.conf
@@ -23,18 +23,18 @@ Microsoft = select,Auto,Global-Office,EU-West,interval=300,timeout=3
 
 [Rule]
 # Streaming services
-RULE-SET,https://raw.githubusercontent.com/lwmmedia/proxy-rules/main/rules/streaming/youtube.list,YouTube,tag=YouTube,enabled=true
-RULE-SET,https://raw.githubusercontent.com/lwmmedia/proxy-rules/main/rules/streaming/netflix.list,Netflix,tag=Netflix,enabled=true
+RULE-SET,https://raw.githubusercontent.com/lwmmedia/proxy-rules/main/rules/streaming/youtube.list,YouTube
+RULE-SET,https://raw.githubusercontent.com/lwmmedia/proxy-rules/main/rules/streaming/netflix.list,Netflix
 
 # Social platforms
-RULE-SET,https://raw.githubusercontent.com/lwmmedia/proxy-rules/main/rules/social/telegram.list,Telegram,tag=Telegram,enabled=true
-RULE-SET,https://raw.githubusercontent.com/lwmmedia/proxy-rules/main/rules/social/discord.list,Discord,tag=Discord,enabled=true
-RULE-SET,https://raw.githubusercontent.com/lwmmedia/proxy-rules/main/rules/social/twitter.list,Twitter,tag=Twitter,enabled=true
+RULE-SET,https://raw.githubusercontent.com/lwmmedia/proxy-rules/main/rules/social/telegram.list,Telegram
+RULE-SET,https://raw.githubusercontent.com/lwmmedia/proxy-rules/main/rules/social/discord.list,Discord
+RULE-SET,https://raw.githubusercontent.com/lwmmedia/proxy-rules/main/rules/social/twitter.list,Twitter
 
 # Global tech services
-RULE-SET,https://raw.githubusercontent.com/lwmmedia/proxy-rules/main/rules/global/google.list,Google,tag=Google,enabled=true
-RULE-SET,https://raw.githubusercontent.com/lwmmedia/proxy-rules/main/rules/global/apple.list,Apple,tag=Apple,enabled=true
-RULE-SET,https://raw.githubusercontent.com/lwmmedia/proxy-rules/main/rules/global/microsoft.list,Microsoft,tag=Microsoft,enabled=true
+RULE-SET,https://raw.githubusercontent.com/lwmmedia/proxy-rules/main/rules/global/google.list,Google
+RULE-SET,https://raw.githubusercontent.com/lwmmedia/proxy-rules/main/rules/global/apple.list,Apple
+RULE-SET,https://raw.githubusercontent.com/lwmmedia/proxy-rules/main/rules/global/microsoft.list,Microsoft
 
 # Fallback rules
 GEOIP,CN,DIRECT


### PR DESCRIPTION
Removes the invalid 'tag' and 'enabled' parameters from the RULE-SET directives in the Loon configuration file. This change corrects the grammar error and ensures the configuration is valid.