### PR TITLE
feat: ajouter les fichiers de santé communautaire

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,16 @@
+# Ces liens apparaissent dans le bouton "Sponsor" de votre dépôt GitHub.
+# Choisissez les plateformes supportées et renseignez votre identifiant.
+# Documentation : https://docs.github.com/articles/displaying-a-sponsor-button-in-your-repository
+
+# GitHub Sponsors — remplacez par votre nom d'utilisateur GitHub si vous y participez
+# github: lwmmedia
+
+# Plateformes tierces (décommentez et renseignez votre identifiant)
+# ko_fi: votre_identifiant
+# buy_me_a_coffee: votre_identifiant
+# patreon: votre_identifiant
+# open_collective: votre_projet
+# liberapay: votre_identifiant
+
+# Lien personnalisé (site, Paypal, Stripe…)
+# custom: https://votre-lien-de-don.example.com

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Code de Conduite — Pacte des Contributeurs
+
+## Notre Engagement
+
+Dans l'intérêt de favoriser un environnement ouvert et accueillant, nous, contributeurs et mainteneurs, nous engageons à faire de la participation à notre projet et à notre communauté une expérience sans harcèlement pour tous, indépendamment de l'âge, la taille corporelle, le handicap, l'origine ethnique, les caractéristiques sexuelles, l'identité et l'expression de genre, le niveau d'expérience, l'éducation, le statut socio-économique, la nationalité, l'apparence personnelle, la race, la religion ou l'identité et l'orientation sexuelles.
+
+## Nos Standards
+
+Exemples de comportements qui contribuent à créer un environnement positif :
+
+- Utiliser un langage accueillant et inclusif
+- Respecter les différents points de vue et expériences
+- Accepter gracieusement les critiques constructives
+- Se concentrer sur ce qui est le mieux pour la communauté
+- Faire preuve d'empathie envers les autres membres de la communauté
+
+Exemples de comportements inacceptables :
+
+- L'utilisation de langage ou d'images sexualisés et les attentions ou avances sexuelles non désirées
+- Le trolling, les commentaires insultants ou désobligeants et les attaques personnelles ou politiques
+- Le harcèlement public ou privé
+- La publication d'informations privées d'autrui, telles que des adresses physiques ou électroniques, sans autorisation explicite
+- Toute autre conduite qui pourrait raisonnablement être considérée comme inappropriée dans un cadre professionnel
+
+## Nos Responsabilités
+
+Les mainteneurs du projet sont responsables de la clarification des standards de comportement acceptable et sont tenus de prendre des mesures correctives appropriées et équitables en réponse à tout cas de comportement inacceptable.
+
+Les mainteneurs du projet ont le droit et la responsabilité de supprimer, modifier ou rejeter les commentaires, commits, code, éditions du wiki, issues et autres contributions qui ne sont pas alignés sur ce Code de Conduite, ou d'interdire temporairement ou définitivement tout contributeur pour des comportements qu'ils jugent inappropriés, menaçants, offensants ou nuisibles.
+
+## Portée
+
+Ce Code de Conduite s'applique aussi bien dans les espaces du projet que dans les espaces publics lorsqu'un individu représente le projet ou sa communauté. Les exemples de représentation d'un projet ou d'une communauté comprennent l'utilisation d'une adresse e-mail officielle du projet, la publication via un compte de réseau social officiel, ou agir en tant que représentant désigné lors d'un événement en ligne ou hors ligne.
+
+## Application
+
+Les cas de comportement abusif, harcelant ou autrement inacceptable peuvent être signalés en contactant l'équipe du projet via les [Issues GitHub](https://github.com/lwmmedia/Proxy-rules-public/issues). Toutes les plaintes seront examinées et feront l'objet d'une enquête et donneront lieu à une réponse jugée nécessaire et appropriée aux circonstances. L'équipe du projet est tenue de respecter la confidentialité à l'égard du rapporteur d'un incident.
+
+Les mainteneurs du projet qui ne respectent pas ou n'appliquent pas le Code de Conduite de bonne foi peuvent faire face à des répercussions temporaires ou permanentes déterminées par d'autres membres de la direction du projet.
+
+## Attribution
+
+Ce Code de Conduite est adapté du [Pacte des Contributeurs](https://www.contributor-covenant.org), version 2.1, disponible à l'adresse https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Guide de Contribution
+
+Merci de votre intérêt pour **Proxy Rules Public** ! Ce document explique comment contribuer efficacement au projet.
+
+## Avant de Commencer
+
+- Vérifiez les [Issues existantes](https://github.com/lwmmedia/Proxy-rules-public/issues) pour éviter les doublons.
+- Pour les grandes modifications, ouvrez d'abord une Issue afin d'en discuter.
+- Assurez-vous d'avoir lu le [Code de Conduite](CODE_OF_CONDUCT.md).
+
+## Types de Contributions
+
+### Ajouter un nouveau fichier de règles
+
+1. **Fork** le dépôt et créez une branche depuis `main` :
+   ```bash
+   git checkout -b ajout/nom-du-service
+   ```
+
+2. **Créez** votre fichier dans la catégorie appropriée :
+   - `rules/streaming/` — Services vidéo/audio (YouTube, Netflix, Twitch…)
+   - `rules/social/` — Réseaux sociaux et messagerie (Telegram, Discord…)
+   - `rules/global/` — Services tech internationaux (Google, Apple, Microsoft…)
+
+3. **Nommez** le fichier en minuscules : `nomduservice.list`
+
+4. **Respectez** le format standard :
+   ```ini
+   # Nom du Service — description courte
+   # Domaines principaux
+   DOMAIN-SUFFIX,exemple.com
+   DOMAIN-SUFFIX,api.exemple.com
+   # CDN et ressources statiques
+   DOMAIN-SUFFIX,cdn.exemple.com
+   # IP ranges si nécessaire
+   IP-CIDR,1.2.3.0/24,no-resolve
+   ```
+
+5. **Testez** vos règles dans une application proxy (Loon, Shadowrocket ou Stash) avant de soumettre.
+
+6. **Mettez à jour** le `README.md` : ajoutez votre service dans le tableau correspondant.
+
+7. **Soumettez** une Pull Request avec :
+   - Un titre clair : `feat: ajouter les règles pour [Service]`
+   - Une description indiquant les domaines couverts et comment vous avez testé
+
+### Corriger des règles existantes
+
+- Signalez d'abord via une Issue avec le label `bug`.
+- Fournissez le domaine manquant ou incorrect et la preuve de son appartenance au service.
+- Les PR de correction doivent inclure un message de commit explicite : `fix: ajouter domaine CDN manquant pour Netflix`.
+
+### Améliorer la documentation
+
+- Corrections de fautes, clarifications, traductions : directement en PR.
+- Restructuration importante : ouvrez une Issue en premier.
+
+## Standards de Qualité des Règles
+
+| Critère | Attendu |
+|---|---|
+| **Domaines officiels** | Uniquement des domaines légitimes du service |
+| **Couverture** | Inclure les domaines principaux, API, CDN et médias |
+| **Tests** | Vérifiés dans au moins une application proxy |
+| **Commentaires** | Expliquer les domaines non évidents |
+| **Format** | Syntaxe cohérente, une règle par ligne |
+
+## Convention de Messages de Commit
+
+```
+type: description courte en français
+
+# Types acceptés :
+feat:   ajout d'un nouveau fichier de règles ou d'une fonctionnalité
+fix:    correction d'un domaine manquant ou incorrect
+docs:   modification de la documentation uniquement
+chore:  maintenance, mise à jour des dépendances
+```
+
+## Signaler un Problème
+
+Utilisez les [Issues GitHub](https://github.com/lwmmedia/Proxy-rules-public/issues) en précisant :
+
+- **Service concerné** et nom du fichier `.list`
+- **Application proxy** utilisée (Loon, Shadowrocket, Stash) et sa version
+- **Comportement observé** vs **comportement attendu**
+- **Domaine(s) problématique(s)** si identifiés
+
+## Questions ?
+
+Ouvrez une Issue avec le label `question`. Nous faisons de notre mieux pour répondre rapidement.


### PR DESCRIPTION
- CODE_OF_CONDUCT.md : Code de conduite basé sur le Pacte des Contributeurs v2.1
- CONTRIBUTING.md : Guide de contribution avec standards de qualité, conventions
  de commits et process de PR adapté au projet de règles proxy
- .github/FUNDING.yml : Configuration du bouton Sponsor GitHub avec commentaires
  pour activer les plateformes souhaitées (GitHub Sponsors, Ko-fi, etc.)

https://claude.ai/code/session_0133YMxLBrKE8uRLmkiXvwsN